### PR TITLE
Fix incompatibility with TS4.7

### DIFF
--- a/lib/validators/functional.ts
+++ b/lib/validators/functional.ts
@@ -28,7 +28,7 @@ export type ValuesOf< T extends { } > = T[ keyof T ] & unknown;
 
 export type FlattenObject< T > = { [ K in keyof T ]: T[ K ] & unknown; };
 
-export type AdditionalProperties< T, U > =
+export type AdditionalProperties< T extends { }, U > =
 	FlattenObject< T & Record< string, U | ValuesOf< T > > >;
 
 export type TypeOf< T, InclRequired = false > =


### PR DESCRIPTION
Hi, after upgrading to TypeScript 4.7 I got this error:

```
Error: node_modules/suretype/dist/validators/functional.d.ts:25:96 - error TS2344: Type 'T' does not satisfy the constraint '{}'.

25 export declare type AdditionalProperties<T, U> = FlattenObject<T & Record<string, U | ValuesOf<T>>>;
                                                                                                  ~

  node_modules/suretype/dist/validators/functional.d.ts:25:42
    25 export declare type AdditionalProperties<T, U> = FlattenObject<T & Record<string, U | ValuesOf<T>>>;
                                                ~
    This type parameter might need an `extends {}` constraint.
```

I am implementing the suggested resolution.